### PR TITLE
Better python version coverage in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: python
+dist: xenial
 python:
   # Python 2
   - "2.7"
   # Python 3
   - "3.5"
   - "3.6"
-  - "3.7-dev"
-  # - "3.7"
-  # - "3.8-dev"
+  - "3.7"
+  - "3.8-dev"
 install:
   - pip install -r requirements.txt
 script:


### PR DESCRIPTION
Added TravisCI support for the stable version of Python 3.7 and development version of Python 3.8